### PR TITLE
Record rules during profiling of ETL scripts (fixes #51)

### DIFF
--- a/plugins/org.eclipse.epsilon.etl.engine/src/org/eclipse/epsilon/etl/dom/TransformationRule.java
+++ b/plugins/org.eclipse.epsilon.etl.engine/src/org/eclipse/epsilon/etl/dom/TransformationRule.java
@@ -16,6 +16,7 @@ import org.eclipse.epsilon.common.parse.AST;
 import org.eclipse.epsilon.common.util.AstUtil;
 import org.eclipse.epsilon.common.util.CollectionUtil;
 import org.eclipse.epsilon.eol.dom.ExecutableBlock;
+import org.eclipse.epsilon.eol.dom.IExecutableModuleElementParameter;
 import org.eclipse.epsilon.eol.dom.Parameter;
 import org.eclipse.epsilon.eol.exceptions.EolRuntimeException;
 import org.eclipse.epsilon.eol.execute.context.IEolContext;
@@ -26,7 +27,7 @@ import org.eclipse.epsilon.erl.dom.ExtensibleNamedRule;
 import org.eclipse.epsilon.etl.execute.context.IEtlContext;
 import org.eclipse.epsilon.etl.parse.EtlParser;
 
-public class TransformationRule extends ExtensibleNamedRule {
+public class TransformationRule extends ExtensibleNamedRule implements IExecutableModuleElementParameter {
 	
 	protected Parameter sourceParameter;
 	protected List<Parameter> targetParameters = new ArrayList<>(2);
@@ -211,7 +212,6 @@ public class TransformationRule extends ExtensibleNamedRule {
 	}
 	
 	protected void executeSuperRulesAndBody(Object source, Collection<Object> targets_, IEtlContext context) throws EolRuntimeException {
-		
 		List<Object> targets = CollectionUtil.asList(targets_);
 		// Execute super-rules
 		for (ExtensibleNamedRule rule : superRules) {
@@ -228,8 +228,8 @@ public class TransformationRule extends ExtensibleNamedRule {
 			Parameter tp = targetParameters.get(offset);
 			variables[i] = Variable.createReadOnlyVariable(tp.getName(), targets.get(offset));
 		}
-		
-		body.execute(context, variables);
+
+		context.getExecutorFactory().execute(this, context, variables);
 	}
 	
 	@Override
@@ -268,5 +268,14 @@ public class TransformationRule extends ExtensibleNamedRule {
 	public void dispose() {
 		rejected = null;
 		transformedElements = null;
+	}
+
+	
+	/**
+	 * TEMPORARY: get Rules tab working again (think about better fix?)
+	 */
+	@Override
+	public Object execute(IEolContext context, Object variables) throws EolRuntimeException {
+		return body.execute(context, (Variable[]) variables);
 	}
 }


### PR DESCRIPTION
This PR is to fix issue #51. The problem was that the RuleProfiler never gets to screen a `TransformationRule`, because its `executeSuperRulesAndBody` method directly executes the body `StatementBlock` so the `TransformationRule` never goes through the preExecute and postExecute methods of the execution controller.

I have moved the place from which the body is run: `TransformationRule` now implements `IExecutableModuleElementParameter`, and the `executeSuperRulesAndBody` method sets everything up and then puts the `TransformationRule` through the execution controller as usual.

I also had to modify the `ExecutionProfiler`, as it assumed that you would never nest rule executions. Turns out this is wrong: an ETL rule can trigger a lazy ETL rule, for instance (or you could use the `satisfies(...)` operation in EVL).

This pull request is only a draft for now, since I'd like for someone else to look at this and tell me if the approach is correct before I start adding automated tests for it. @kolovos, could you give it a look?