### PR TITLE
[EOL] Fix incorrect import failure reason

### DIFF
--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/EolModule.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/EolModule.java
@@ -414,7 +414,7 @@ public class EolModule extends AbstractModule implements IEolModule {
 					ParseProblem problem = new ParseProblem();
 					problem.setLine(import_.getRegion().getStart().getLine());
 
-					String reason = import_.isFound()
+					String reason = !import_.isFound()
 							? String.format("File %s not found", import_.getPath())
 							: String.format("File %s contains errors: %s", import_.getPath(),
 									import_.getModule().getParseProblems());


### PR DESCRIPTION
Fixes issue where parse problem is reported as "File ... contains errors: []" when the file is not found and "File ... not found" when there are parse problems