### PR TITLE
Fix conflict around CommonMark versions since Eclipse 2024-12

### DIFF
--- a/examples/org.eclipse.epsilon.examples.eol.dap/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.epsilon.examples.eol.dap/META-INF/MANIFEST.MF
@@ -15,7 +15,6 @@ Require-Bundle: org.eclipse.epsilon.eol.engine,
  org.eclipse.jetty.http;bundle-version="12.0.0",
  org.eclipse.jetty.util;bundle-version="12.0.0",
  org.eclipse.jetty.io;bundle-version="12.0.0",
- org.slf4j.api;bundle-version="1.7.2",
  org.eclipse.epsilon.egl.engine
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.epsilon.examples.eol.dap

--- a/plugins/org.eclipse.epsilon.picto/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.epsilon.picto/META-INF/MANIFEST.MF
@@ -31,16 +31,14 @@ Require-Bundle: org.eclipse.epsilon.flexmi,
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.epsilon.eol.dt,
- com.atlassian.commonmark,
- com.atlassian.commonmark-gfm-strikethrough,
- com.atlassian.commonmark-gfm-tables,
- com.atlassian.commonmark-heading-anchor,
- com.atlassian.commonmark-image-attributes,
- com.atlassian.commonmark-ins,
- com.atlassian.commonmark-task-list-items,
- com.atlassian.commonmark-yaml,
  org.apache.commons.csv,
- wrapped.net.sourceforge.plantuml.plantuml-epl;bundle-version="1.2023.11"
+ wrapped.net.sourceforge.plantuml.plantuml-epl;bundle-version="1.2023.11",
+ org.commonmark;bundle-version="0.24.0",
+ org.commonmark-gfm-strikethrough;bundle-version="0.24.0",
+ org.commonmark-gfm-tables;bundle-version="0.24.0",
+ org.commonmark-image-attributes;bundle-version="0.24.0",
+ org.commonmark-ins;bundle-version="0.24.0",
+ org.commonmark-yaml-front-matter;bundle-version="0.24.0"
 Bundle-Activator: org.eclipse.epsilon.picto.PictoPlugin
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.epsilon.picto,

--- a/releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.target
+++ b/releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Epsilon Target Platform" sequenceNumber="1721808586">
+<target name="Epsilon Target Platform" sequenceNumber="1735815198">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -29,7 +29,7 @@
       <unit id="org.eclipse.xtext.runtime.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.cdo.sdk.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2023-12"/>
+      <repository location="https://download.eclipse.org/releases/2024-12"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.emf.emfatic.feature.group" version="0.0.0"/>
@@ -43,14 +43,6 @@
       <repository location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202401051648"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="com.atlassian.commonmark" version="0.15.1.v20200707-1444"/>
-      <unit id="com.atlassian.commonmark-gfm-strikethrough" version="0.15.1.v20200707-1444"/>
-      <unit id="com.atlassian.commonmark-gfm-tables" version="0.15.1.v20200707-1444"/>
-      <unit id="com.atlassian.commonmark-heading-anchor" version="0.15.1.v20200707-1444"/>
-      <unit id="com.atlassian.commonmark-image-attributes" version="0.15.1.v20200707-1444"/>
-      <unit id="com.atlassian.commonmark-ins" version="0.15.1.v20200707-1444"/>
-      <unit id="com.atlassian.commonmark-task-list-items" version="0.15.1.v20200707-1444"/>
-      <unit id="com.atlassian.commonmark-yaml" version="0.15.1.v20200707-1444"/>
       <unit id="com.google.gdata" version="1.47.1.v20200819-2030"/>
       <unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
       <unit id="javax.annotation" version="1.3.5.v20200909-1856"/>
@@ -97,39 +89,48 @@
       <unit id="org.eclipse.mylyn.wikitext.markdown.ui" version="0.0.0"/>
       <repository location="https://download.eclipse.org/mylyn/updates/release/4.3.0/"/>
     </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.commonmark" version="0.0.0"/>
+      <unit id="org.commonmark-gfm-strikethrough" version="0.0.0"/>
+      <unit id="org.commonmark-gfm-tables" version="0.0.0"/>
+      <unit id="org.commonmark-ins" version="0.0.0"/>
+      <unit id="org.commonmark-yaml-front-matter" version="0.0.0"/>
+      <unit id="org.commonmark-image-attributes" version="0.0.0"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-12"/>
+    </location>
     <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test,runtime" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
-    <dependencies>
-    	<dependency>
-    		<groupId>net.sourceforge.plantuml</groupId>
-    		<artifactId>plantuml-epl</artifactId>
-    		<version>1.2023.11</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>com.googlecode.json-simple</groupId>
-    		<artifactId>json-simple</artifactId>
-    		<version>1.1.1</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.apache.poi</groupId>
-    		<artifactId>poi</artifactId>
-    		<version>4.1.2</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.apache.poi</groupId>
-    		<artifactId>poi-ooxml</artifactId>
-    		<version>4.1.2</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.apache.poi</groupId>
-    		<artifactId>poi-ooxml-schemas</artifactId>
-    		<version>4.1.2</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
+      <dependencies>
+        <dependency>
+          <groupId>net.sourceforge.plantuml</groupId>
+          <artifactId>plantuml-epl</artifactId>
+          <version>1.2023.11</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>com.googlecode.json-simple</groupId>
+          <artifactId>json-simple</artifactId>
+          <version>1.1.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.poi</groupId>
+          <artifactId>poi</artifactId>
+          <version>4.1.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.poi</groupId>
+          <artifactId>poi-ooxml</artifactId>
+          <version>4.1.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.poi</groupId>
+          <artifactId>poi-ooxml-schemas</artifactId>
+          <version>4.1.2</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>

--- a/releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.tpd
+++ b/releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.tpd
@@ -4,7 +4,7 @@ location "https://download.eclipse.org/cbi/updates/license" {
 	org.eclipse.license.feature.group lazy
 }
 
-location "https://download.eclipse.org/releases/2023-12" {
+location "https://download.eclipse.org/releases/2024-12" {
 	org.eclipse.e4.core.tools.feature.feature.group lazy
 	org.eclipse.emf.sdk.feature.group lazy
 	org.eclipse.emf.validation.sdk.feature.group lazy
@@ -40,14 +40,6 @@ location "https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3
 }
 
 location "https://download.eclipse.org/tools/orbit/downloads/drops/R20211213173813/repository" {
-	com.atlassian.commonmark [0.15.1,0.15.2)
-	com.atlassian.commonmark-gfm-strikethrough [0.15.1,0.15.2)
-	com.atlassian.commonmark-gfm-tables [0.15.1,0.15.2)
-	com.atlassian.commonmark-heading-anchor [0.15.1,0.15.2)
-	com.atlassian.commonmark-image-attributes [0.15.1,0.15.2)
-	com.atlassian.commonmark-ins [0.15.1,0.15.2)
-	com.atlassian.commonmark-task-list-items [0.15.1,0.15.2)
-	com.atlassian.commonmark-yaml [0.15.1,0.15.2)
 	com.google.gdata [1.47.1,1.47.2)
 	javax.xml.stream [1.0.1,1.0.2)
 	javax.annotation [1.3.5,1.4.0)
@@ -93,6 +85,16 @@ location "https://download.eclipse.org/mylyn/updates/release/4.3.0/" {
 	org.eclipse.mylyn.wikitext lazy
 	org.eclipse.mylyn.wikitext.markdown lazy
 	org.eclipse.mylyn.wikitext.markdown.ui lazy
+}
+
+// Needed by Picto
+location "https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-12" {
+	org.commonmark lazy
+	org.commonmark-gfm-strikethrough lazy
+	org.commonmark-gfm-tables lazy
+	org.commonmark-ins lazy
+	org.commonmark-yaml-front-matter lazy
+	org.commonmark-image-attributes lazy
 }
 
 maven MavenDependencies scope=compile,test,runtime dependencyDepth=infinite missingManifest=generate includeSources {

--- a/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/ParseProblemTests.java
+++ b/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/ParseProblemTests.java
@@ -9,10 +9,8 @@
  **********************************************************************/
 package org.eclipse.epsilon.eol.engine.test.acceptance;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -34,12 +32,10 @@ public class ParseProblemTests {
 		EolModule module = new EolModule();
 		module.parse("import \"missing.eol\";");
 		assertEquals(1, module.getParseProblems().size());
-		assertThat("Expected parse problem is raised",
-			module.getParseProblems().get(0).getReason(),
-			allOf(
-				containsString("not found"),
-				containsString("missing.eol")
-			));
+
+		String sReason = module.getParseProblems().get(0).getReason();
+		assertTrue("Expected parse problem is raised", sReason.contains("not found"));
+		assertTrue("Expected problem file is mentioned", sReason.contains("missing.eol"));
 	}
 
 	@Test
@@ -57,12 +53,10 @@ public class ParseProblemTests {
 		EolModule module = new EolModule();
 		module.parse(String.format("import \"%s\";", fParseProblems.toURI()));
 		assertEquals(1, module.getParseProblems().size());
-		assertThat("Expected parse problem is raised",
-			module.getParseProblems().get(0).getReason(),
-			allOf(
-				containsString("contains errors"),
-				containsString("parseProblems.eol")
-			));
+
+		String sReason = module.getParseProblems().get(0).getReason();
+		assertTrue("Expected parse problem is raised", sReason.contains("contains errors"));
+		assertTrue("Expected problem file is mentioned", sReason.contains("parseProblems.eol"));
 	}
 
 }


### PR DESCRIPTION
Related to #144. As the reporter mentioned, Picto was on an old version of CommonMark for Java (0.15.0) and it was conflicting with the 0.24.0 version being used in Eclipse 2024-12.

This PR upgrades the target platform to 2024-12, and switches to the CommonMark 0.24.0 release in the Orbit SimRel 2024-12 update site.