### PR TITLE
[EGL] Fix some parse problems reporting incorrect position

### DIFF
--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/internal/EglModule.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/internal/EglModule.java
@@ -206,8 +206,11 @@ public class EglModule extends EolModule implements IEglModule {
 
 	@Override
 	public List<ParseProblem> getParseProblems() {
-		parseProblems.addAll(eglParser.getParseProblems());
+		if (!eglParser.getParseProblems().isEmpty()) {
+			return eglParser.getParseProblems();
+		}
 		
+		// If preprocessor has run then replace the problems with ones that are trace aware
 		for (int index = 0; index < parseProblems.size(); index++) {
 			final ParseProblem problem = parseProblems.get(index);
 			

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/AcceptanceTestUtil.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/AcceptanceTestUtil.java
@@ -64,6 +64,10 @@ public class AcceptanceTestUtil {
 		return run(factory, program, models);
 	}
 	
+	public static void parse(Object program) throws Exception {
+		setup(new EglFileGeneratingTemplateFactory(), program);
+	}
+	
 	@SuppressWarnings("restriction")
 	private static void setup(EglTemplateFactory factory, Object program, IModel... models) throws Exception {
 		factory.getContext().getModelRepository().addModels(models);

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/EglAcceptanceTestSuite.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/EglAcceptanceTestSuite.java
@@ -23,6 +23,7 @@ import org.eclipse.epsilon.egl.test.acceptance.outdentation.OutdentationTests;
 import org.eclipse.epsilon.egl.test.acceptance.output.Output;
 import org.eclipse.epsilon.egl.test.acceptance.output.lineNumbers.CurrentLineNumber;
 import org.eclipse.epsilon.egl.test.acceptance.output.newlines.OutputNewlines;
+import org.eclipse.epsilon.egl.test.acceptance.parse.ParseProblemTests;
 import org.eclipse.epsilon.egl.test.acceptance.patch.PatchTestSuite;
 import org.eclipse.epsilon.egl.test.acceptance.stop.Stop;
 import org.eclipse.epsilon.egl.test.acceptance.traceability.Traceability;
@@ -49,7 +50,8 @@ import junit.framework.Test;
                Formatters.class,
                PatchTestSuite.class,
                OutdentationTests.class,
-               ImportCachingTests.class})
+               ImportCachingTests.class,
+               ParseProblemTests.class})
 public class EglAcceptanceTestSuite {
 
 	public static Test suite() {

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/parse/ParseProblemTests.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/parse/ParseProblemTests.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2025 The University of York.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * Contributors:
+ *     Sam Harris - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.epsilon.egl.test.acceptance.parse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Collection;
+
+import org.eclipse.epsilon.common.parse.problem.ParseProblem;
+import org.eclipse.epsilon.egl.test.acceptance.AcceptanceTestUtil;
+import org.eclipse.epsilon.egl.util.FileUtil;
+import org.junit.Test;
+
+public class ParseProblemTests {
+
+	@Test
+	public void parseProblemReportsCorrectPosition() throws Exception {
+		final String program = "[*Generate foo*]" + FileUtil.NEWLINE
+							+ "<h1>[%='foo'[%='foo'%]</h1>";
+		
+		AcceptanceTestUtil.parse(program);
+		Collection<ParseProblem> problems = AcceptanceTestUtil.getParseProblems();
+		
+		assertFalse(problems.isEmpty());
+		
+		ParseProblem problem = problems.iterator().next();
+		
+		assertEquals(2, problem.getLine());
+		assertEquals(13, problem.getColumn());
+	}
+	
+	@Test
+	public void parseProblemReportsCorrectPositionEOF() throws Exception {
+		final String program = "[*Generate foo*]" + FileUtil.NEWLINE
+							+ "<h1>[%='foo'%</h1>";
+		
+		AcceptanceTestUtil.parse(program);
+		Collection<ParseProblem> problems = AcceptanceTestUtil.getParseProblems();
+		
+		assertFalse(problems.isEmpty());
+		
+		ParseProblem problem = problems.iterator().next();
+		
+		assertEquals(2, problem.getLine());
+		assertEquals(19, problem.getColumn());
+	}
+}


### PR DESCRIPTION
Fixes #166 

The issue was caused by the `EglParseProblem` assuming that the preprocessing had been done however some parse problems can happen before preprocessing and in those cases preprocessing does not run.