### PR TITLE
Limit target platform maven dependencies scope to compile

### DIFF
--- a/releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.target
+++ b/releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Epsilon Target Platform" sequenceNumber="1738582007">
+<target name="Epsilon Target Platform" sequenceNumber="1747230076">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -97,7 +97,7 @@
       <unit id="org.commonmark-image-attributes" version="0.0.0"/>
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-12"/>
     </location>
-    <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test,runtime" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
       <dependencies>
         <dependency>
           <groupId>net.sourceforge.plantuml</groupId>

--- a/releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.tpd
+++ b/releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.tpd
@@ -96,7 +96,7 @@ location "https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024
 	org.commonmark-image-attributes lazy
 }
 
-maven MavenDependencies scope=compile,test,runtime dependencyDepth=infinite missingManifest=generate includeSources {
+maven MavenDependencies scope=compile dependencyDepth=infinite missingManifest=generate includeSources {
 	dependency {
 		groupId="net.sourceforge.plantuml"
 		artifactId="plantuml-epl"


### PR DESCRIPTION
Necessary to make the target platform load properly in Eclipse 2025-03

Related to [this m2e-core issue](https://github.com/eclipse-m2e/m2e-core/issues/1976).