### PR TITLE
Draft: EVL fix debugging

### DIFF
--- a/examples/org.eclipse.epsilon.examples.eol.dap/Run Debug Adapter on 09-validate from Ant.launch
+++ b/examples/org.eclipse.epsilon.examples.eol.dap/Run Debug Adapter on 09-validate from Ant.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.ant.AntLaunchConfigurationType">
+    <booleanAttribute key="org.eclipse.ant.ui.DEFAULT_VM_INSTALL" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.eclipse.epsilon.examples.eol.dap/build.xml"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.epsilon.examples.eol.dap"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_ANT_TARGETS" value="09-validate,"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/org.eclipse.epsilon.examples.eol.dap/build.xml}"/>
+    <stringAttribute key="process_factory_id" value="org.eclipse.ant.ui.remoteAntProcessFactory"/>
+</launchConfiguration>

--- a/examples/org.eclipse.epsilon.examples.eol.dap/build.xml
+++ b/examples/org.eclipse.epsilon.examples.eol.dap/build.xml
@@ -42,9 +42,9 @@
 		<epsilon.emf.loadModel name="M"
 			metamodelfile="epsilon/models/person.ecore"
 			modelfile="epsilon/models/invalidPerson.model"
-			read="true" store="false" />
+			read="true" store="true" />
 
-		<epsilon.evl src="epsilon/09-validate.evl" debug="true" debugPort="4040" failOnErrors="false">
+		<epsilon.evl src="epsilon/09-validate.evl" debug="true" debugPort="4040" failOnErrors="false" fix="true">
 			<model ref="M"/>
 		</epsilon.evl>
 

--- a/examples/org.eclipse.epsilon.examples.eol.dap/build.xml
+++ b/examples/org.eclipse.epsilon.examples.eol.dap/build.xml
@@ -38,6 +38,19 @@
 		<epsilon.disposeModel model="M" />
 	</target>
 
+	<target name="09-validate">
+		<epsilon.emf.loadModel name="M"
+			metamodelfile="epsilon/models/person.ecore"
+			modelfile="epsilon/models/invalidPerson.model"
+			read="true" store="false" />
+
+		<epsilon.evl src="epsilon/09-validate.evl" debug="true" debugPort="4040" failOnErrors="false">
+			<model ref="M"/>
+		</epsilon.evl>
+
+		<epsilon.disposeModel model="M" />
+	</target>
+
 	<target name="start-server">
 		<epsilon.startDebugServer />
 	</target>

--- a/examples/org.eclipse.epsilon.examples.eol.dap/epsilon/09-validate.evl
+++ b/examples/org.eclipse.epsilon.examples.eol.dap/epsilon/09-validate.evl
@@ -1,0 +1,19 @@
+context Person {
+  constraint HasFirstName {
+    check: self.firstName.isDefined()
+    message: 'Missing first name'
+  }
+  constraint HasLastName {
+    guard: self.firstName.isDefined()
+    check: self.lastName.isDefined()
+    message: 'Missing last name for ' + self.firstName
+    fix {
+      guard: true
+      title: 'Add placeholder last name'
+      do {
+        var newLastName = 'Unknown';
+        self.lastName = newLastName;
+      }
+    }
+  }
+}

--- a/examples/org.eclipse.epsilon.examples.eol.dap/epsilon/models/invalidPerson.model
+++ b/examples/org.eclipse.epsilon.examples.eol.dap/epsilon/models/invalidPerson.model
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="ASCII"?>
+<Model xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns="http://eclipse.org/epsilon/examples/person" xmi:id="_q24fMEVLEfCmEN4rtoP3hA">
+  <people xmi:id="_rWjdwEVLEfCmEN4rtoP3hA" firstName="John" lastName=""/>
+</Model>

--- a/plugins/org.eclipse.epsilon.emc.emf/src/org/eclipse/epsilon/emc/emf/AbstractEmfModel.java
+++ b/plugins/org.eclipse.epsilon.emc.emf/src/org/eclipse/epsilon/emc/emf/AbstractEmfModel.java
@@ -363,7 +363,7 @@ public abstract class AbstractEmfModel extends CachedModel<EObject> {
 
 	@Override
 	public boolean owns(Object instance) {	
-		if (instance instanceof EObject) {
+		if (instance instanceof EObject && modelImpl != null) {
 			EObject eObject = (EObject) instance;
 			Resource eObjectResource = eObject.eResource();
 			

--- a/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
+++ b/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
@@ -143,6 +143,9 @@ public class EpsilonDebugAdapter implements IDebugProtocolServer {
 					 * completed.
 					 */
 					topModule = (IEolModule) ast.getModule();
+					while (topModule.getParentModule() != null) {
+						topModule = topModule.getParentModule();
+					}
 				}
 
 				/*

--- a/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
+++ b/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
@@ -132,7 +132,7 @@ public class EpsilonDebugAdapter implements IDebugProtocolServer {
 
 		@Override
 		public void aboutToExecute(ModuleElement ast, IEolContext context) {
-			if (ast.getParent() == null) {
+			if (ast.getParent() == null || runningRoots.isEmpty()) {
 				runningRoots.add(ast);
 
 				if (topElement == null) {
@@ -159,8 +159,8 @@ public class EpsilonDebugAdapter implements IDebugProtocolServer {
 					}
 				}
 
-				if (ast instanceof IEolModule) {
-					ThreadState threadState = attachTo((IEolModule) ast);
+				if (ast.getModule() instanceof IEolModule) {
+					ThreadState threadState = attachTo((IEolModule) ast.getModule());
 					sendThreadEvent(threadState.getThreadId(), ThreadEventArgumentsReason.STARTED);
 				}
 			}
@@ -168,8 +168,7 @@ public class EpsilonDebugAdapter implements IDebugProtocolServer {
 
 		@Override
 		public void finishedExecuting(ModuleElement ast, Object result, IEolContext context) {
-			if (ast.getParent() == null) {
-				runningRoots.remove(ast);
+			if (runningRoots.remove(ast)) {
 				if (ast instanceof IEolModule) {
 					final IEolModule eolModule = (IEolModule) ast;
 					eolModule.getContext().getOutputStream().flush();

--- a/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
+++ b/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
@@ -169,11 +169,11 @@ public class EpsilonDebugAdapter implements IDebugProtocolServer {
 		@Override
 		public void finishedExecuting(ModuleElement ast, Object result, IEolContext context) {
 			if (runningRoots.remove(ast)) {
-				if (ast instanceof IEolModule) {
-					final IEolModule eolModule = (IEolModule) ast;
+				if (ast.getModule() instanceof IEolModule) {
+					final IEolModule eolModule = (IEolModule) ast.getModule();
 					eolModule.getContext().getOutputStream().flush();
 					eolModule.getContext().getErrorStream().flush();
-					removeThreadFor((IEolModule) ast);
+					removeThreadFor(eolModule);
 				}
 			}
 			if (ast == topElement) {

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/EolDebugger.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/EolDebugger.java
@@ -101,8 +101,6 @@ public class EolDebugger implements IEolDebugger {
 		} catch (InterruptedException ex) {
 			ex.printStackTrace();
 		}
-	
-		if (isTerminated()) return;
 	}
 
 	@Override
@@ -135,6 +133,12 @@ public class EolDebugger implements IEolDebugger {
 	@Override
 	public void stepReturn() {
 		stopAfterFrameStackSizeDropsBelow = frameStackSize();
+	}
+
+	@Override
+	public boolean isDoneAfterModuleElement(ModuleElement ast) {
+		// Default behaviour: execution is done after running the module
+		return ast == getModule();
 	}
 
 	private boolean controls(ModuleElement ast) {

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/IEolDebugger.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/IEolDebugger.java
@@ -32,4 +32,10 @@ public interface IEolDebugger extends ExecutionController {
 
 	Integer getStopAfterFrameStackSizeDropsBelow();
 
+	/**
+	 * Returns true iff the execution will complete after the
+	 * given module element completes (i.e. no further elements
+	 * will be run from this execution).
+	 */
+	boolean isDoneAfterModuleElement(ModuleElement ast);
 }

--- a/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/debug/EvlDebugger.java
+++ b/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/debug/EvlDebugger.java
@@ -11,15 +11,38 @@ package org.eclipse.epsilon.evl.debug;
 
 import org.eclipse.epsilon.common.module.ModuleElement;
 import org.eclipse.epsilon.eol.debug.EolDebugger;
+import org.eclipse.epsilon.evl.EvlModule;
 import org.eclipse.epsilon.evl.dom.Constraint;
 import org.eclipse.epsilon.evl.dom.ConstraintContext;
 import org.eclipse.epsilon.evl.dom.Fix;
+import org.eclipse.epsilon.evl.execute.UnsatisfiedConstraint;
 
 public class EvlDebugger extends EolDebugger {
 	
 	@Override
 	protected boolean isStructuralBlock(ModuleElement ast) {
 		return super.isStructuralBlock(ast) || ast instanceof ConstraintContext || ast instanceof Constraint || ast instanceof Fix;
+	}
+
+	@Override
+	public boolean isDoneAfterModuleElement(ModuleElement ast) {
+		if (super.isDoneAfterModuleElement(ast)) {
+			for (UnsatisfiedConstraint unsatisfied : getModule().getContext().getUnsatisfiedConstraints()) {
+				if (!unsatisfied.getFixes().isEmpty()) {
+					// There is at least one unsatisfied constraint with fixes: leave it running
+					return false;
+				}
+			}
+
+			// no unsatisfied constraints with fixes: EVL script will end as usual
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public EvlModule getModule() {
+		return (EvlModule) super.getModule();
 	}
 	
 }

--- a/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/debug/EvlDebugger.java
+++ b/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/debug/EvlDebugger.java
@@ -27,6 +27,11 @@ public class EvlDebugger extends EolDebugger {
 	@Override
 	public boolean isDoneAfterModuleElement(ModuleElement ast) {
 		if (super.isDoneAfterModuleElement(ast)) {
+			if (getModule().getUnsatisfiedConstraintFixer() == null) {
+				// There is no fixer to apply the fixes
+				return true;
+			}
+
 			for (UnsatisfiedConstraint unsatisfied : getModule().getContext().getUnsatisfiedConstraints()) {
 				if (!unsatisfied.isFixed() && !unsatisfied.getFixes().isEmpty()) {
 					// There is at least one unfixed unsatisfied constraint with fixes: leave it running

--- a/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/debug/EvlDebugger.java
+++ b/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/debug/EvlDebugger.java
@@ -28,8 +28,8 @@ public class EvlDebugger extends EolDebugger {
 	public boolean isDoneAfterModuleElement(ModuleElement ast) {
 		if (super.isDoneAfterModuleElement(ast)) {
 			for (UnsatisfiedConstraint unsatisfied : getModule().getContext().getUnsatisfiedConstraints()) {
-				if (!unsatisfied.getFixes().isEmpty()) {
-					// There is at least one unsatisfied constraint with fixes: leave it running
+				if (!unsatisfied.isFixed() && !unsatisfied.getFixes().isEmpty()) {
+					// There is at least one unfixed unsatisfied constraint with fixes: leave it running
 					return false;
 				}
 			}

--- a/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/execute/CommandLineFixer.java
+++ b/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/execute/CommandLineFixer.java
@@ -17,8 +17,6 @@ import org.eclipse.epsilon.evl.execute.context.IEvlContext;
 
 public class CommandLineFixer implements IEvlFixer {
 
-	protected boolean fix = false;
-	
 	@Override
 	public void fix(IEvlModule module) throws EolRuntimeException {
 		IEvlContext context = module.getContext();
@@ -26,7 +24,7 @@ public class CommandLineFixer implements IEvlFixer {
 		
 		for (UnsatisfiedConstraint unsatisfiedConstraint : context.getUnsatisfiedConstraints()) {
 			context.getOutputStream().println(unsatisfiedConstraint.getMessage());
-			boolean fixIt = fix && (unsatisfiedConstraint.getFixes().size() > 0) && userInput.confirm("Fix error?", true);
+			boolean fixIt = unsatisfiedConstraint.getFixes().size() > 0 && userInput.confirm("Fix error?", true);
 			
 			if (fixIt) {
 				FixInstance fixInstance = (FixInstance) userInput.choose(unsatisfiedConstraint.getMessage(), unsatisfiedConstraint.getFixes(), null);
@@ -37,12 +35,4 @@ public class CommandLineFixer implements IEvlFixer {
 		}
 	}
 
-	public boolean isFix() {
-		return fix;
-	}
-
-	public void setFix(boolean fix) {
-		this.fix = fix;
-	}
-	
 }

--- a/plugins/org.eclipse.epsilon.workflow/ant/org/eclipse/epsilon/workflow/tasks/EvlTask.java
+++ b/plugins/org.eclipse.epsilon.workflow/ant/org/eclipse/epsilon/workflow/tasks/EvlTask.java
@@ -21,6 +21,7 @@ import org.eclipse.epsilon.evl.execute.UnsatisfiedConstraint;
 public class EvlTask extends ExportableModuleTask {
 	
 	protected String exportConstraintTrace;
+	protected boolean fix = false;
 	
 	public String getExportConstraintTrace() {
 		return exportConstraintTrace;
@@ -32,6 +33,14 @@ public class EvlTask extends ExportableModuleTask {
 		}
 	}
 
+	public boolean isFix() {
+		return fix;
+	}
+
+	public void setFix(boolean fix) {
+		this.fix = fix;
+	}
+
 	@Override
 	protected IEvlModule createDefaultModule() {
 		return new EvlModuleParallelAnnotation();
@@ -40,9 +49,10 @@ public class EvlTask extends ExportableModuleTask {
 	@Override
 	protected void initialize() throws Exception {
 		IEvlModule evlModule = (IEvlModule) module;
-		CommandLineFixer clf = new CommandLineFixer();
-		clf.setFix(false);
-		evlModule.setUnsatisfiedConstraintFixer(clf);
+		if (isFix()) {
+			CommandLineFixer clf = new CommandLineFixer();
+			evlModule.setUnsatisfiedConstraintFixer(clf);
+		}
 	}
 
 	@Override

--- a/tests/org.eclipse.epsilon.eol.dap.test/epsilon/11-validation.evl
+++ b/tests/org.eclipse.epsilon.eol.dap.test/epsilon/11-validation.evl
@@ -10,9 +10,14 @@ context Person {
       return l.isDefined() and l.trim().length() > 0;
     }
     fix {
-      title: 'Add "NoLastName" as placeholder'
+      guard: true // just to have a place for a breakpoint
+      title {
+        var newLastName = 'NoLastName';
+        return 'Add "' + newLastName + '" as placeholder';
+      }
       do {
-        self.lastName = 'NoLastName';
+        var fixedLastName = 'NoLastName';
+        self.lastName = fixedLastName;
       }
     }
   }

--- a/tests/org.eclipse.epsilon.eol.dap.test/epsilon/11-validation.evl
+++ b/tests/org.eclipse.epsilon.eol.dap.test/epsilon/11-validation.evl
@@ -9,5 +9,11 @@ context Person {
       var l = self.lastName;
       return l.isDefined() and l.trim().length() > 0;
     }
+    fix {
+      title: 'Add "NoLastName" as placeholder'
+      do {
+        self.lastName = 'NoLastName';
+      }
+    }
   }
 }

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/AbstractEpsilonDebugAdapterTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/AbstractEpsilonDebugAdapterTest.java
@@ -170,13 +170,15 @@ public abstract class AbstractEpsilonDebugAdapterTest {
 	}
 
 	@After
-	public void teardown() {
+	public void teardown() throws InterruptedException {
+		adapter.disconnect(new DisconnectArguments());
+		executor.shutdown();
+		executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
 		if (module != null) {
 			module.getContext().getModelRepository().dispose();
 			module.getContext().dispose();
 		}
-		adapter.disconnect(new DisconnectArguments());
-		executor.shutdownNow();
 	}
 
 	protected void assertStoppedBecauseOf(final String expectedReason) throws InterruptedException {

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/AbstractEpsilonDebugAdapterTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/AbstractEpsilonDebugAdapterTest.java
@@ -10,6 +10,7 @@
 package org.eclipse.epsilon.eol.dap.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -198,7 +199,7 @@ public abstract class AbstractEpsilonDebugAdapterTest {
 	protected void assertProgramFailed() throws InterruptedException {
 		client.isExited.tryAcquire(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 		assertNotNull("The script should have exited within " + TIMEOUT_SECONDS + " seconds", client.exitedArgs);
-		assertEquals("The script should have completed its execution with an error", 1, client.exitedArgs.getExitCode());
+		assertNotEquals("The script should have completed its execution with an error", 0, client.exitedArgs.getExitCode());
 	}
 
 	protected StackTraceResponse getStackTrace() throws Exception {

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/AbstractExecutionQueueTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/AbstractExecutionQueueTest.java
@@ -33,7 +33,7 @@ public abstract class AbstractExecutionQueueTest extends AbstractEpsilonDebugAda
 		adapter.terminate(new TerminateArguments());
 	
 		// Ensures the program has finished running, and that the script thread has died
-		assertProgramCompletedSuccessfully();
+		assertProgramFailed();
 		runModuleResult.get();
 	}
 

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/AbstractExecutionQueueTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/AbstractExecutionQueueTest.java
@@ -34,7 +34,7 @@ public abstract class AbstractExecutionQueueTest extends AbstractEpsilonDebugAda
 	
 		// Ensures the program has finished running, and that the script thread has died
 		assertProgramCompletedSuccessfully();
-		epsilonThread.join();
+		runModuleResult.get();
 	}
 
 }

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/EpsilonDebugAdapterTestSuite.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/EpsilonDebugAdapterTestSuite.java
@@ -42,6 +42,7 @@ import org.eclipse.epsilon.eol.dap.test.epl.EplDebugTest;
 import org.eclipse.epsilon.eol.dap.test.etl.EtlDebugTest;
 import org.eclipse.epsilon.eol.dap.test.eunit.EUnitDebugTest;
 import org.eclipse.epsilon.eol.dap.test.evl.EvlDebugTest;
+import org.eclipse.epsilon.eol.dap.test.evl.EvlFixDebugTest;
 import org.eclipse.epsilon.eol.dap.test.flock.FlockDebugTest;
 import org.eclipse.epsilon.eol.dap.test.pinset.PinsetDebugTest;
 import org.junit.runner.RunWith;
@@ -77,6 +78,7 @@ import junit.framework.Test;
     ClasspathEgxTest.class,
     EgxErrorInEglTest.class,
     EvlDebugTest.class,
+    EvlFixDebugTest.class,
     EtlDebugTest.class,
     EclDebugTest.class,
     EmlDebugTest.class,

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/eml/EmlDebugTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/eml/EmlDebugTest.java
@@ -28,7 +28,6 @@ import org.eclipse.lsp4j.debug.ContinueArguments;
 import org.eclipse.lsp4j.debug.SetBreakpointsResponse;
 import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
 import org.eclipse.lsp4j.debug.Variable;
-import org.junit.Before;
 import org.junit.Test;
 
 public class EmlDebugTest extends AbstractEpsilonDebugAdapterTest {

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/eol/StandaloneEolTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/eol/StandaloneEolTest.java
@@ -156,7 +156,7 @@ public class StandaloneEolTest extends AbstractEpsilonDebugAdapterTest {
 		attach();
 		assertStoppedBecauseOf(StoppedEventArgumentsReason.BREAKPOINT);
 
-		adapter.terminate(new TerminateArguments());
+		adapter.terminate(new TerminateArguments()).get();
 		assertProgramFailed();
 	}
 

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/evl/EvlFixDebugTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/evl/EvlFixDebugTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2024 The University of York.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.epsilon.eol.dap.test.evl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.eclipse.epsilon.eol.dap.test.AbstractEpsilonDebugAdapterTest;
+import org.eclipse.epsilon.eol.dap.test.metamodel.Person;
+import org.eclipse.epsilon.eol.models.java.JavaModel;
+import org.eclipse.epsilon.evl.EvlModule;
+import org.eclipse.epsilon.evl.execute.UnsatisfiedConstraint;
+import org.eclipse.lsp4j.debug.ContinueArguments;
+import org.eclipse.lsp4j.debug.ScopesResponse;
+import org.eclipse.lsp4j.debug.SetBreakpointsResponse;
+import org.eclipse.lsp4j.debug.StackTraceResponse;
+import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.eclipse.lsp4j.debug.Variable;
+import org.eclipse.lsp4j.debug.VariablesResponse;
+import org.junit.Test;
+
+public class EvlFixDebugTest extends AbstractEpsilonDebugAdapterTest {
+
+	private static final File SCRIPT_FILE = new File(BASE_RESOURCE_FOLDER, "11-validation.evl");
+
+	@Override
+	protected void setupModule() throws Exception {
+		this.module = new EvlModule();
+		module.parse(SCRIPT_FILE);
+
+		final ArrayList<Object> objects = new ArrayList<Object>();
+		objects.add(new Person("John", null));
+		final JavaModel model = new JavaModel("M", objects, new ArrayList<>(Arrays.asList(Person.class)));
+		module.getContext().getModelRepository().addModel(model);
+	}
+
+	@Test
+	public void canStopInsideFixTitleExpression() throws Exception {
+		SetBreakpointsResponse breakpoints = adapter.setBreakpoints(
+			createBreakpoints(createBreakpoint(13))).get();
+		assertTrue("The breakpoint on the file should be recognised",
+			breakpoints.getBreakpoints()[0].isVerified());
+		assertEquals("The breakpoint should be verified on the fix expression",
+			(Integer) 13, breakpoints.getBreakpoints()[0].getLine());
+		attach();
+
+		// Wait for the EVL script to run
+		runModuleResult.get();
+
+		// Try to get the title of the first fix
+		Future<String> futureTitle = executor.submit(() -> {
+			Collection<UnsatisfiedConstraint> allUnsatisfied = 
+				((EvlModule) module).getContext().getUnsatisfiedConstraints();
+			UnsatisfiedConstraint unsatisfied = allUnsatisfied.iterator().next();
+			return unsatisfied.getFixes().get(0).getTitle();
+		});
+
+		assertStoppedBecauseOf(StoppedEventArgumentsReason.BREAKPOINT);
+		assertFalse("Computing the title should not be done yet", futureTitle.isDone());
+		StackTraceResponse stackTrace = getStackTrace();
+		assertEquals("Shold be stopped at the fix title expression line",
+			13, stackTrace.getStackFrames()[0].getLine());
+
+		ScopesResponse scopes = getScopes(stackTrace.getStackFrames()[1]);
+		VariablesResponse variables = getVariables(scopes.getScopes()[0]);
+		Map<String, Variable> varsByName = getVariablesByName(variables);
+		Variable personVariable = varsByName.get("self");
+		assertNotNull("The second stack frame should have a 'self' variable", personVariable);
+
+		adapter.continue_(new ContinueArguments()).get();
+		assertNotNull(futureTitle.get());
+		assertProgramCompletedSuccessfully();
+	}
+}

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/evl/EvlFixDebugTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/evl/EvlFixDebugTest.java
@@ -31,6 +31,7 @@ import org.eclipse.lsp4j.debug.ScopesResponse;
 import org.eclipse.lsp4j.debug.SetBreakpointsResponse;
 import org.eclipse.lsp4j.debug.StackTraceResponse;
 import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.eclipse.lsp4j.debug.TerminateArguments;
 import org.eclipse.lsp4j.debug.Variable;
 import org.eclipse.lsp4j.debug.VariablesResponse;
 import org.junit.Test;
@@ -85,6 +86,11 @@ public class EvlFixDebugTest extends AbstractEpsilonDebugAdapterTest {
 
 		adapter.continue_(new ContinueArguments()).get();
 		assertNotNull(futureTitle.get());
-		assertProgramCompletedSuccessfully();
+
+		// We need to explicitly terminate as there is a lingering fix that could be applied
+		adapter.terminate(new TerminateArguments()).get();
+
+		// Terminated programs exit with a non-zero status
+		assertProgramFailed();
 	}
 }


### PR DESCRIPTION
Fixes #187.

Here is a WIP pull request for adding debugging support to EVL fixes.

This is trickier than it seems, as it breaks an assumption we had in our DAP support: that modules ran to completion and then finished. I had to move the concept of when a module was "done" to a new method in the IEolDebugger interface: the `done()` method in IEolDebugger doesn't work as it is called after the execution listener's `finishedExecuting` method, which is where the debug adapter reacts to the program having completed its execution.

I also had to tweak the EVL UI in Eclipse so that it won't block when we hit a breakpoint in the middle of applying a fix. We need to do something similar for computing the titles of the fixes, but this means we have to change from a context menu, to something like the "quick fixes" dialog in Eclipse.

@kolovos, would you be OK with the above change in the Validation view?