### PR TITLE
Fix for context propagation in the presence of circular imports

### DIFF
--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/EolModule.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/EolModule.java
@@ -174,7 +174,6 @@ public class EolModule extends AbstractModule implements IEolModule {
 		
 		operations.addAll(this.getDeclaredOperations());
 		for (Import import_ : imports) {
-			import_.setContext(context);
 			if (import_.isLoaded() && import_.getModule() instanceof IEolModule) {
 				operations.addAll(((IEolModule)import_.getModule()).getOperations());
 			}

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/ImportManager.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/ImportManager.java
@@ -24,8 +24,13 @@ public class ImportManager implements IImportManager {
 
 	@Override
 	public void loadModuleForImport(Import import_, Class<? extends IModule> moduleImplClass, URI baseURI) throws URISyntaxException {
-		String importPath = import_.getPath();
+		/*
+		 * The cache should contain the importing module as well,
+		 * to reuse modules in the presence of dependency cycles.
+		 */
+		cache.put(baseURI, import_.getParentModule());
 
+		final String importPath = import_.getPath();
 		final URI importUri = UriUtil.resolve(importPath, baseURI).normalize();
 		final IEolModule parentModule = import_.getParentModule();
 		

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/dom/Import.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/dom/Import.java
@@ -74,6 +74,9 @@ public class Import extends AbstractModuleElement {
 			}
 			if (!found) {
 				try {
+					if (importedModule instanceof IEolModule) {
+						((IEolModule) importedModule).setContext(parentModule.getContext());
+					}
 					importedModule.parse(uri);
 				}
 				catch (Exception e) {

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/EglAcceptanceTestSuite.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/EglAcceptanceTestSuite.java
@@ -16,6 +16,7 @@ import org.eclipse.epsilon.egl.test.acceptance.eol.ConsistencyWithEolSuite;
 import org.eclipse.epsilon.egl.test.acceptance.exceptions.Exceptions;
 import org.eclipse.epsilon.egl.test.acceptance.extensibility.Extensibility;
 import org.eclipse.epsilon.egl.test.acceptance.formatters.Formatters;
+import org.eclipse.epsilon.egl.test.acceptance.imports.CircularImportsTests;
 import org.eclipse.epsilon.egl.test.acceptance.imports.ImportCachingTests;
 import org.eclipse.epsilon.egl.test.acceptance.merge.Merge;
 import org.eclipse.epsilon.egl.test.acceptance.operations.template.TemplateOperations;
@@ -51,7 +52,8 @@ import junit.framework.Test;
                PatchTestSuite.class,
                OutdentationTests.class,
                ImportCachingTests.class,
-               ParseProblemTests.class})
+               ParseProblemTests.class,
+               CircularImportsTests.class})
 public class EglAcceptanceTestSuite {
 
 	public static Test suite() {


### PR DESCRIPTION
This is a suggested fix for #203. It removes the clobbering of module contexts in EolModule::build(), and instead propagates the context via the Import::load() method.

This works more reliably in the presence of circular imports, as the parent module's context is present from the start while parsing the imported module.