### PR TITLE
Fix to restore use of relative paths from main EGX script in imported EGX modules

### DIFF
--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EgxModule.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EgxModule.java
@@ -178,25 +178,33 @@ public class EgxModule extends ErlModule implements IEgxModule {
 	
 	@Override
 	public boolean parse(File file) throws Exception {
-		boolean result = super.parse(file);
-		if (result) getContext().getTemplateFactory().initialiseRoot(file.getAbsoluteFile().getParentFile().toURI());
-		return result;
+		/*
+		 * Note: root must be initialised before parsing starts, so that the template
+		 * factory uses the main EGX script as its root (instead of the first EGX script
+		 * that fully parses without adding any new imports).
+		 */
+		URI rootURI = file.getAbsoluteFile().getParentFile().toURI();
+		getContext().getTemplateFactory().initialiseRoot(rootURI);
+		return super.parse(file);
 	}
 	
 	@Override
 	public boolean parse(URI uri) throws Exception {
-		boolean result = super.parse(uri);
-		if (result) getContext().getTemplateFactory().initialiseRoot(uri);
-		return result;
+		// See comment in parse(File) about root initialisation
+		getContext().getTemplateFactory().initialiseRoot(uri);
+		return super.parse(uri);
 	}
 	
 	@Override
 	public boolean parse(String code, File file) throws Exception {
-		boolean result = super.parse(code, file);
-		if (result && file != null) getContext().getTemplateFactory().initialiseRoot(file.getAbsoluteFile().getParentFile().toURI());
-		return result;
+		// See comment in parse(File) about root initialisation
+		if (file != null) {
+			URI rootURI = file.getAbsoluteFile().getParentFile().toURI();
+			getContext().getTemplateFactory().initialiseRoot(rootURI);
+		}
+		return super.parse(code, file);
 	}
-	
+
 	@Override
 	protected Object processRules() throws EolRuntimeException {
 		IEgxContext context = getContext();

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/EgxAcceptanceTestSuite.java
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/EgxAcceptanceTestSuite.java
@@ -14,6 +14,7 @@ import org.eclipse.epsilon.egx.engine.test.acceptance.equivalence.EgxModuleEquiv
 import org.eclipse.epsilon.egx.engine.test.acceptance.extendedproperties.ExtendedPropertiesTests;
 import org.eclipse.epsilon.egx.engine.test.acceptance.formatter.FormatterTests;
 import org.eclipse.epsilon.egx.engine.test.acceptance.hutn.EgxHutnTestSuite;
+import org.eclipse.epsilon.egx.engine.test.acceptance.imports.SubfolderImportTest;
 import org.eclipse.epsilon.egx.engine.test.acceptance.operations.IncludeTests;
 import org.eclipse.epsilon.egx.engine.test.acceptance.operations.PrintTests;
 import org.eclipse.epsilon.egx.engine.test.acceptance.parse.GenerationRuleConstructsTests;
@@ -33,7 +34,8 @@ import junit.framework.Test;
 	GenerationRuleConstructsTests.class,
 	EgxModuleEquivalenceTests.class,
 	FormatterTests.class,
-	ExtendedPropertiesTests.class
+	ExtendedPropertiesTests.class,
+	SubfolderImportTest.class
 })
 public class EgxAcceptanceTestSuite {
 

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/SubfolderImportTest.java
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/SubfolderImportTest.java
@@ -1,0 +1,55 @@
+package org.eclipse.epsilon.egx.engine.test.acceptance.imports;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.epsilon.common.util.FileUtil;
+import org.eclipse.epsilon.egl.EgxModule;
+import org.eclipse.epsilon.emc.emf.EmfModel;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SubfolderImportTest {
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+	
+	@Test
+	public void importRootIsPreserved() throws Exception {
+		File mainEgx = FileUtil.getFileStandalone("main.egx", getClass());
+		for (String path : new String[] {
+			"java.ecore",
+			"barchart/barchart.egx", "barchart/stats.egl",
+			"dot/dot.egx", "dot/ecore2dot.egl"
+		}) {
+			FileUtil.getFileStandalone(path, getClass());
+		}
+
+		File outputFolder = folder.getRoot();
+		EgxModule module = new EgxModule(outputFolder.getAbsolutePath());
+		module.parse(mainEgx);
+
+		EmfModel model = new EmfModel();
+		model.setMetamodelUri(EcorePackage.eNS_URI);
+		model.setModelFile(new File(mainEgx.getParentFile(), "java.ecore").getAbsolutePath());
+		model.setReadOnLoad(true);
+		model.setStoredOnDisposal(false);
+		model.load();
+
+		module.getContext().getModelRepository().addModel(model);
+		module.execute();
+		
+		assertFolderHasFile(outputFolder, "barchart.txt");
+		assertFolderHasFile(outputFolder, "ecoredot.txt");
+	}
+
+	protected void assertFolderHasFile(File folder, String expectedFilename) {
+		FilenameFilter filter = (dir, filename) -> expectedFilename.equals(filename);
+		String message = String.format("File %s is in folder %s", expectedFilename, folder);
+		assertTrue(message, folder.listFiles(filter).length > 0);
+	}
+}

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/barchart/barchart.egx
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/barchart/barchart.egx
@@ -1,0 +1,10 @@
+rule Ecore2Barchart {
+	template : "barchart/stats.egl"
+	parameters : Map {
+		"classes" = EClass.all, 
+		"format" = "html",
+		"path" = List{"Model", "Stats"},
+		"icon" = "barchart"
+	}
+	target : "barchart.txt"
+}

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/barchart/stats.egl
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/barchart/stats.egl
@@ -1,0 +1,33 @@
+<html>
+  <head>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script type="text/javascript">
+      google.charts.load('current', {'packages':['bar']});
+      google.charts.setOnLoadCallback(drawChart);
+
+      function drawChart() {
+        var data = google.visualization.arrayToDataTable([
+          ['Type', '#'],
+          ['Classes', [%=EClass.all.size()%]],
+          ['Attributes', [%=EAttribute.all.size()%]],
+          ['References', [%=EReference.all.size()%]]
+        ]);
+
+        var options = {
+          chart: {
+            title: 'Stats',
+            subtitle: '# of elements per type',
+          },
+          bars: 'horizontal' // Required for Material Bar Charts.
+        };
+
+        var chart = new google.charts.Bar(document.getElementById('barchart_material'));
+
+        chart.draw(data, google.charts.Bar.convertOptions(options));
+      }
+    </script>
+  </head>
+  <body>
+    <div id="barchart_material" style="width: 900px; height: 300px;"></div>
+  </body>
+</html>

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/dot/dot.egx
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/dot/dot.egx
@@ -1,0 +1,10 @@
+rule All2Dot {
+	template : "dot/ecore2dot.egl"
+	parameters : Map {
+		"classes" = EClass.all, 
+		"format" = "graphviz-dot",
+		"path" = List{"Model", "(All classes)"},
+		"icon" = "diagram-ff0000"
+	}
+	target : "ecoredot.txt"
+}

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/dot/ecore2dot.egl
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/dot/ecore2dot.egl
@@ -1,0 +1,115 @@
+digraph G {
+	graph[splines=ortho]
+	node[fontname=Tahoma, fontsize=10, shape=record]
+	edge[fontname=Tahoma, fontsize=10, dir=back, arrowtail=empty]
+	 
+	[%for (c in classes) { %]
+	[%=c.name%][shape=none, margin=0, label = <[%=c.getLabel()%]>]
+	[%for (s in c.eSuperTypes.select(c|classes.includes(c))){%]
+	[%=s.name%]->[%=c.name%]
+	[%}%]
+	[%}%]
+	
+	[%for (r in EReference.all.select(r|classes.includes(r.eContainer) and classes.includes(r.eType))) {%]
+	[%=r.eContainer.name%]->[%=r.eType.name%][label=" [%=r.getLabel()%] ",arrowtail=[%=r.getArrowTail()%]];
+	[%}%]
+	
+}
+
+[%
+
+operation EClass getLabel() {
+	var fillcolor = "fffcdc";
+	var label = "<table cellspacing='0' cellborder='0' cellpadding='1' bgcolor='#" + fillcolor + "'>";
+	var features = self.eAttributes;
+	
+	label += "<tr><td sides='B' colspan='2' border='1'>" + 
+		"<table border='0' cellspacing='0' cellborder='0' cellpading='0'>" + 
+		"<tr><td align='right' valign='middle'><img src='" + self.getIcon()+ "'></img></td>" + 
+		"<td align='left' valign='middle' href=\"javascript:top.showView('/Model/Classes/" + self.name + "')\" tooltip='Go'>" + self.name + "</td></tr></table></td></tr>";
+	
+	for (f in features.sortBy(f|f.name.toLowerCase())) {
+		label += "<tr>";
+		label += "<td><img src='" + f.getIcon() + "'></img></td><td align='left'>" + f.getLabel(self) + "</td>";
+		label += "</tr>";
+	}
+	if (features.isEmpty()){
+		label += "<tr>";
+		label += "<td>&nbsp;</td><td>&nbsp;</td>";
+		label += "</tr>";
+	}
+	
+	label += "</table>";
+	return label;
+}
+
+operation EStructuralFeature getLabel(eClass : EClass) {
+	var label = self.name;
+	if (self.eType.isDefined()) label += " : " + self.eType.name;
+	if (self.isMany) label += "["+"*"+"]";
+	if (self.isTypeOf(EReference)) {
+		// add href here
+	}
+	return label; 
+}
+
+operation EOperation getLabel() {
+	var label = self.name + "(" + self.eParameters.collect(p|p.getLabel()).concat(", ") + ")";
+	if (self.eType.isDefined()) {
+		label += " : " + self.eType.name;
+		if (self.isMany) {
+			label += "["+"*"+"]";
+		}
+	}
+	return label;
+}
+
+operation EReference getArrowTail() {
+	if (self.containment) {
+		return "diamond";
+	}
+	else {
+		return "none";
+	}
+}
+
+operation Any getIcon() {
+	return new Native("java.io.File")
+		(System.context.module.file.parent, "icons/" + self.eClass.name + ".gif").absolutePath;
+}
+
+
+operation EReference getLabel() {
+	var label = self.name;
+	if (self.isMany) label += "*";
+	return label; 
+}
+/*
+operation ETypedElement getLabel() {
+	var label = self.name + " : " + self.eType.name;
+	if (self.isMany) label += "["+"*"+"]";
+	return label;  
+}
+
+operation EOperation getLabel() {
+	var label = self.name + "(" + self.eParameters.collect(p|p.getLabel()).concat(", ") + ")";
+	if (self.eType.isDefined()) {
+		label += " : " + self.eType.name;
+		if (self.isMany) {
+			label += "["+"*"+"]";
+		}
+	}
+	return label;
+}
+
+operation EReference getArrowTail() {
+	if (self.containment) {
+		return "diamond";
+	}
+	else {
+		return "none";
+	}
+}*/
+
+%]
+

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/java.ecore
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/java.ecore
@@ -1,0 +1,713 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="javaMM" nsURI="http://www.eclipse.org/MoDisco/Java/0.2.incubation/java"
+    nsPrefix="javaMM">
+  <eClassifiers xsi:type="ecore:EClass" name="AbstractMethodDeclaration" abstract="true"
+      eSuperTypes="#//BodyDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" eType="#//Block"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameters" upperBound="-1"
+        eType="#//SingleVariableDeclaration" containment="true" eOpposite="#//SingleVariableDeclaration/methodDeclaration"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="thrownExceptions" upperBound="-1"
+        eType="#//TypeAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeParameters" upperBound="-1"
+        eType="#//TypeParameter" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usagesInDocComments" ordered="false"
+        upperBound="-1" eType="#//MethodRef" eOpposite="#//MethodRef/method"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usages" ordered="false"
+        upperBound="-1" eType="#//AbstractMethodInvocation" eOpposite="#//AbstractMethodInvocation/method"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AbstractMethodInvocation" abstract="true"
+      eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="method" ordered="false"
+        lowerBound="1" eType="#//AbstractMethodDeclaration" eOpposite="#//AbstractMethodDeclaration/usages"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="arguments" upperBound="-1"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeArguments" upperBound="-1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AbstractTypeDeclaration" abstract="true"
+      eSuperTypes="#//BodyDeclaration #//Type">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="bodyDeclarations" upperBound="-1"
+        eType="#//BodyDeclaration" containment="true" eOpposite="#//BodyDeclaration/abstractTypeDeclaration"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="commentsBeforeBody" upperBound="-1"
+        eType="#//Comment" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="commentsAfterBody" upperBound="-1"
+        eType="#//Comment" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="package" ordered="false"
+        eType="#//Package" eOpposite="#//Package/ownedElements"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="superInterfaces" upperBound="-1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AbstractTypeQualifiedExpression" abstract="true"
+      eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="qualifier" ordered="false"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AbstractVariablesContainer" abstract="true"
+      eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" eType="#//TypeAccess"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="fragments" upperBound="-1"
+        eType="#//VariableDeclarationFragment" containment="true" eOpposite="#//VariableDeclarationFragment/variablesContainer"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Annotation" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1"
+        eType="#//AnnotationMemberValuePair" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Archive" eSuperTypes="#//NamedElement">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="originalFilePath" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="classFiles" ordered="false"
+        upperBound="-1" eType="#//ClassFile" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="manifest" ordered="false"
+        eType="#//Manifest" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AssertStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="message" ordered="false"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ASTNode" abstract="true">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="comments" upperBound="-1"
+        eType="#//Comment" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="originalCompilationUnit"
+        ordered="false" eType="#//CompilationUnit"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="originalClassFile" ordered="false"
+        eType="#//ClassFile"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AnnotationMemberValuePair" eSuperTypes="#//NamedElement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="member" ordered="false"
+        eType="#//AnnotationTypeMemberDeclaration" eOpposite="#//AnnotationTypeMemberDeclaration/usages"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="value" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AnnotationTypeDeclaration" eSuperTypes="#//AbstractTypeDeclaration"/>
+  <eClassifiers xsi:type="ecore:EClass" name="AnnotationTypeMemberDeclaration" eSuperTypes="#//BodyDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="default" ordered="false"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usages" ordered="false"
+        upperBound="-1" eType="#//AnnotationMemberValuePair" eOpposite="#//AnnotationMemberValuePair/member"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AnonymousClassDeclaration" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="bodyDeclarations" upperBound="-1"
+        eType="#//BodyDeclaration" containment="true" eOpposite="#//BodyDeclaration/anonymousClassDeclarationOwner"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="classInstanceCreation"
+        ordered="false" eType="#//ClassInstanceCreation" eOpposite="#//ClassInstanceCreation/anonymousClassDeclaration"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ArrayAccess" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="array" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="index" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ArrayCreation" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensions" upperBound="-1"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="initializer" ordered="false"
+        eType="#//ArrayInitializer" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ArrayInitializer" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expressions" upperBound="-1"
+        eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ArrayLengthAccess" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="array" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ArrayType" eSuperTypes="#//Type">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="dimensions" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="elementType" ordered="false"
+        lowerBound="1" eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Assignment" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="leftHandSide" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" ordered="false"
+        unique="false" lowerBound="1" eType="#//AssignmentKind"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="rightHandSide" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BodyDeclaration" abstract="true" eSuperTypes="#//NamedElement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="abstractTypeDeclaration"
+        ordered="false" eType="#//AbstractTypeDeclaration" eOpposite="#//AbstractTypeDeclaration/bodyDeclarations"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotations" upperBound="-1"
+        eType="#//Annotation" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="anonymousClassDeclarationOwner"
+        ordered="false" eType="#//AnonymousClassDeclaration" eOpposite="#//AnonymousClassDeclaration/bodyDeclarations"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="modifier" ordered="false"
+        eType="#//Modifier" containment="true" eOpposite="#//Modifier/bodyDeclaration"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BooleanLiteral" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BlockComment" eSuperTypes="#//Comment"/>
+  <eClassifiers xsi:type="ecore:EClass" name="Block" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="statements" upperBound="-1"
+        eType="#//Statement" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BreakStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="label" ordered="false"
+        eType="#//LabeledStatement" eOpposite="#//LabeledStatement/usagesInBreakStatements"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CastExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CatchClause" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="exception" ordered="false"
+        lowerBound="1" eType="#//SingleVariableDeclaration" containment="true" eOpposite="#//SingleVariableDeclaration/catchClause"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Block" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CharacterLiteral" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="escapedValue" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ClassFile" eSuperTypes="#//NamedElement">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="originalFilePath" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" eType="#//AbstractTypeDeclaration"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="attachedSource" ordered="false"
+        eType="#//CompilationUnit"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="package" ordered="false"
+        eType="#//Package"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ClassInstanceCreation" eSuperTypes="#//Expression #//AbstractMethodInvocation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="anonymousClassDeclaration"
+        ordered="false" eType="#//AnonymousClassDeclaration" containment="true" eOpposite="#//AnonymousClassDeclaration/classInstanceCreation"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConstructorDeclaration" eSuperTypes="#//AbstractMethodDeclaration"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ConditionalExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="elseExpression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="thenExpression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ConstructorInvocation" eSuperTypes="#//Statement #//AbstractMethodInvocation"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ClassDeclaration" eSuperTypes="#//TypeDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="superClass" ordered="false"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Comment" abstract="true" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="content" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="enclosedByParent" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="prefixOfParent" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CompilationUnit" eSuperTypes="#//NamedElement">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="originalFilePath" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="commentList" upperBound="-1"
+        eType="#//Comment"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="imports" upperBound="-1"
+        eType="#//ImportDeclaration" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="package" ordered="false"
+        eType="#//Package"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="types" upperBound="-1"
+        eType="#//AbstractTypeDeclaration"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ContinueStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="label" ordered="false"
+        eType="#//LabeledStatement" eOpposite="#//LabeledStatement/usagesInContinueStatements"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DoStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Statement" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EmptyStatement" eSuperTypes="#//Statement"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EnhancedForStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Statement" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" ordered="false"
+        lowerBound="1" eType="#//SingleVariableDeclaration" containment="true" eOpposite="#//SingleVariableDeclaration/enhancedForStatement"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EnumConstantDeclaration" eSuperTypes="#//BodyDeclaration #//VariableDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="anonymousClassDeclaration"
+        ordered="false" eType="#//AnonymousClassDeclaration" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="arguments" upperBound="-1"
+        eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EnumDeclaration" eSuperTypes="#//AbstractTypeDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="enumConstants" upperBound="-1"
+        eType="#//EnumConstantDeclaration" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Expression" abstract="true" eSuperTypes="#//ASTNode"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ExpressionStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FieldAccess" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="field" ordered="false"
+        lowerBound="1" eType="#//SingleVariableAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FieldDeclaration" eSuperTypes="#//BodyDeclaration #//AbstractVariablesContainer"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ForStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="updaters" upperBound="-1"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="initializers" upperBound="-1"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Statement" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="IfStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="thenStatement" ordered="false"
+        lowerBound="1" eType="#//Statement" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="elseStatement" ordered="false"
+        eType="#//Statement" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ImportDeclaration" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="static" ordered="false"
+        unique="false" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedElement" ordered="false"
+        lowerBound="1" eType="#//NamedElement" eOpposite="#//NamedElement/usagesInImports"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="InfixExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" ordered="false"
+        unique="false" lowerBound="1" eType="#//InfixExpressionKind"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="rightOperand" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="leftOperand" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="extendedOperands" upperBound="-1"
+        eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Initializer" eSuperTypes="#//BodyDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Block" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="InstanceofExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="rightOperand" ordered="false"
+        lowerBound="1" eType="#//TypeAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="leftOperand" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="InterfaceDeclaration" eSuperTypes="#//TypeDeclaration"/>
+  <eClassifiers xsi:type="ecore:EClass" name="Javadoc" eSuperTypes="#//Comment">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="tags" upperBound="-1" eType="#//TagElement"
+        containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LabeledStatement" eSuperTypes="#//NamedElement #//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Statement" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usagesInBreakStatements"
+        ordered="false" upperBound="-1" eType="#//BreakStatement" eOpposite="#//BreakStatement/label"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usagesInContinueStatements"
+        ordered="false" upperBound="-1" eType="#//ContinueStatement" eOpposite="#//ContinueStatement/label"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LineComment" eSuperTypes="#//Comment"/>
+  <eClassifiers xsi:type="ecore:EClass" name="Manifest">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="mainAttributes" ordered="false"
+        upperBound="-1" eType="#//ManifestAttribute" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="entryAttributes" ordered="false"
+        upperBound="-1" eType="#//ManifestEntry" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ManifestAttribute">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" ordered="false" unique="false"
+        lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ManifestEntry">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" ordered="false" unique="false"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="attributes" ordered="false"
+        upperBound="-1" eType="#//ManifestAttribute" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MemberRef" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="member" ordered="false"
+        lowerBound="1" eType="#//NamedElement"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="qualifier" ordered="false"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MethodDeclaration" eSuperTypes="#//AbstractMethodDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="extraArrayDimensions" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="returnType" ordered="false"
+        eType="#//TypeAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="redefinedMethodDeclaration"
+        ordered="false" eType="#//MethodDeclaration" eOpposite="#//MethodDeclaration/redefinitions"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="redefinitions" ordered="false"
+        upperBound="-1" eType="#//MethodDeclaration" eOpposite="#//MethodDeclaration/redefinedMethodDeclaration"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MethodInvocation" eSuperTypes="#//Expression #//AbstractMethodInvocation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MethodRef" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="method" ordered="false"
+        lowerBound="1" eType="#//AbstractMethodDeclaration" eOpposite="#//AbstractMethodDeclaration/usagesInDocComments"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="qualifier" ordered="false"
+        eType="#//TypeAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameters" upperBound="-1"
+        eType="#//MethodRefParameter" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="MethodRefParameter" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" ordered="false" unique="false"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="varargs" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Model">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" ordered="false" unique="false"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedElements" ordered="false"
+        upperBound="-1" eType="#//Package" containment="true" eOpposite="#//Package/model"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="orphanTypes" ordered="false"
+        upperBound="-1" eType="#//Type" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="unresolvedItems" ordered="false"
+        upperBound="-1" eType="#//UnresolvedItem" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="compilationUnits" ordered="false"
+        upperBound="-1" eType="#//CompilationUnit" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="classFiles" ordered="false"
+        upperBound="-1" eType="#//ClassFile" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="archives" ordered="false"
+        upperBound="-1" eType="#//Archive" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Modifier" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="visibility" ordered="false"
+        unique="false" lowerBound="1" eType="#//VisibilityKind"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="inheritance" ordered="false"
+        unique="false" lowerBound="1" eType="#//InheritanceKind"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="static" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="transient" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="volatile" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="native" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="strictfp" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="synchronized" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="bodyDeclaration" ordered="false"
+        eType="#//BodyDeclaration" eOpposite="#//BodyDeclaration/modifier"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="singleVariableDeclaration"
+        ordered="false" eType="#//SingleVariableDeclaration" eOpposite="#//SingleVariableDeclaration/modifier"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variableDeclarationStatement"
+        ordered="false" eType="#//VariableDeclarationStatement" eOpposite="#//VariableDeclarationStatement/modifier"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variableDeclarationExpression"
+        ordered="false" eType="#//VariableDeclarationExpression" eOpposite="#//VariableDeclarationExpression/modifier"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NamedElement" abstract="true" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" ordered="false" unique="false"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="proxy" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usagesInImports" ordered="false"
+        upperBound="-1" eType="#//ImportDeclaration" eOpposite="#//ImportDeclaration/importedElement"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NamespaceAccess" abstract="true" eSuperTypes="#//ASTNode"/>
+  <eClassifiers xsi:type="ecore:EClass" name="NumberLiteral" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="tokenValue" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NullLiteral" eSuperTypes="#//Expression"/>
+  <eClassifiers xsi:type="ecore:EClass" name="Package" eSuperTypes="#//NamedElement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedElements" ordered="false"
+        upperBound="-1" eType="#//AbstractTypeDeclaration" containment="true" eOpposite="#//AbstractTypeDeclaration/package"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="model" ordered="false"
+        eType="#//Model" eOpposite="#//Model/ownedElements"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedPackages" ordered="false"
+        upperBound="-1" eType="#//Package" containment="true" eOpposite="#//Package/package"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="package" ordered="false"
+        eType="#//Package" eOpposite="#//Package/ownedPackages"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usagesInPackageAccess"
+        ordered="false" upperBound="-1" eType="#//PackageAccess" eOpposite="#//PackageAccess/package"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PackageAccess" eSuperTypes="#//NamespaceAccess">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="package" ordered="false"
+        lowerBound="1" eType="#//Package" eOpposite="#//Package/usagesInPackageAccess"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="qualifier" ordered="false"
+        eType="#//PackageAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ParameterizedType" eSuperTypes="#//Type">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeArguments" upperBound="-1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ParenthesizedExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PostfixExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" ordered="false"
+        unique="false" lowerBound="1" eType="#//PostfixExpressionKind"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="operand" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PrefixExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" ordered="false"
+        unique="false" lowerBound="1" eType="#//PrefixExpressionKind"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="operand" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveType" eSuperTypes="#//Type"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeBoolean" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeByte" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeChar" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeDouble" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeShort" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeFloat" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeInt" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeLong" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PrimitiveTypeVoid" eSuperTypes="#//PrimitiveType"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ReturnStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SingleVariableAccess" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variable" ordered="false"
+        lowerBound="1" eType="#//VariableDeclaration" eOpposite="#//VariableDeclaration/usageInVariableAccess"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="qualifier" ordered="false"
+        eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SingleVariableDeclaration" eSuperTypes="#//VariableDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="modifier" ordered="false"
+        eType="#//Modifier" containment="true" eOpposite="#//Modifier/singleVariableDeclaration"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="varargs" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotations" upperBound="-1"
+        eType="#//Annotation" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="methodDeclaration" ordered="false"
+        eType="#//AbstractMethodDeclaration" eOpposite="#//AbstractMethodDeclaration/parameters"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="catchClause" ordered="false"
+        eType="#//CatchClause" eOpposite="#//CatchClause/exception"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="enhancedForStatement" ordered="false"
+        eType="#//EnhancedForStatement" eOpposite="#//EnhancedForStatement/parameter"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Statement" abstract="true" eSuperTypes="#//ASTNode"/>
+  <eClassifiers xsi:type="ecore:EClass" name="StringLiteral" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="escapedValue" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SuperConstructorInvocation" eSuperTypes="#//Statement #//AbstractMethodInvocation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SuperFieldAccess" eSuperTypes="#//AbstractTypeQualifiedExpression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="field" ordered="false"
+        lowerBound="1" eType="#//SingleVariableAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SuperMethodInvocation" eSuperTypes="#//AbstractTypeQualifiedExpression #//AbstractMethodInvocation"/>
+  <eClassifiers xsi:type="ecore:EClass" name="SwitchCase" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="default" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SwitchStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="statements" upperBound="-1"
+        eType="#//Statement" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SynchronizedStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Block" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TagElement" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="tagName" ordered="false"
+        unique="false" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="fragments" upperBound="-1"
+        eType="#//ASTNode" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TextElement" eSuperTypes="#//ASTNode">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" ordered="false" unique="false"
+        lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ThisExpression" eSuperTypes="#//AbstractTypeQualifiedExpression"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ThrowStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TryStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Block" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="finally" ordered="false"
+        eType="#//Block" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="catchClauses" upperBound="-1"
+        eType="#//CatchClause" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Type" abstract="true" eSuperTypes="#//NamedElement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usagesInTypeAccess" ordered="false"
+        upperBound="-1" eType="#//TypeAccess" eOpposite="#//TypeAccess/type"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TypeAccess" eSuperTypes="#//Expression #//NamespaceAccess">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//Type" eOpposite="#//Type/usagesInTypeAccess"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="qualifier" ordered="false"
+        eType="#//NamespaceAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TypeDeclaration" abstract="true" eSuperTypes="#//AbstractTypeDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="typeParameters" upperBound="-1"
+        eType="#//TypeParameter" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TypeDeclarationStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="declaration" ordered="false"
+        lowerBound="1" eType="#//AbstractTypeDeclaration" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TypeLiteral" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" ordered="false" lowerBound="1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TypeParameter" eSuperTypes="#//Type">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="bounds" upperBound="-1"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedItem" eSuperTypes="#//NamedElement"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedItemAccess" eSuperTypes="#//Expression #//NamespaceAccess">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="element" ordered="false"
+        eType="#//UnresolvedItem"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="qualifier" ordered="false"
+        eType="#//ASTNode" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedAnnotationDeclaration" eSuperTypes="#//AnnotationTypeDeclaration #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedAnnotationTypeMemberDeclaration"
+      eSuperTypes="#//AnnotationTypeMemberDeclaration #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedClassDeclaration" eSuperTypes="#//ClassDeclaration #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedEnumDeclaration" eSuperTypes="#//EnumDeclaration #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedInterfaceDeclaration" eSuperTypes="#//InterfaceDeclaration #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedLabeledStatement" eSuperTypes="#//LabeledStatement #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedMethodDeclaration" eSuperTypes="#//MethodDeclaration #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedSingleVariableDeclaration"
+      eSuperTypes="#//SingleVariableDeclaration #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedType" eSuperTypes="#//Type #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedTypeDeclaration" eSuperTypes="#//AbstractTypeDeclaration #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UnresolvedVariableDeclarationFragment"
+      eSuperTypes="#//VariableDeclarationFragment #//UnresolvedItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="VariableDeclaration" abstract="true"
+      eSuperTypes="#//NamedElement">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="extraArrayDimensions" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="initializer" ordered="false"
+        eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="usageInVariableAccess"
+        ordered="false" upperBound="-1" eType="#//SingleVariableAccess" eOpposite="#//SingleVariableAccess/variable"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="VariableDeclarationExpression" eSuperTypes="#//Expression #//AbstractVariablesContainer">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="modifier" ordered="false"
+        eType="#//Modifier" containment="true" eOpposite="#//Modifier/variableDeclarationExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotations" upperBound="-1"
+        eType="#//Annotation" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="VariableDeclarationFragment" eSuperTypes="#//VariableDeclaration">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variablesContainer" ordered="false"
+        eType="#//AbstractVariablesContainer" eOpposite="#//AbstractVariablesContainer/fragments"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="VariableDeclarationStatement" eSuperTypes="#//Statement #//AbstractVariablesContainer">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="extraArrayDimensions" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="modifier" ordered="false"
+        eType="#//Modifier" containment="true" eOpposite="#//Modifier/variableDeclarationStatement"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="annotations" upperBound="-1"
+        eType="#//Annotation" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="WildCardType" eSuperTypes="#//Type">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="upperBound" ordered="false"
+        unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="bound" ordered="false"
+        eType="#//TypeAccess" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="WhileStatement" eSuperTypes="#//Statement">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" ordered="false"
+        lowerBound="1" eType="#//Expression" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" ordered="false" lowerBound="1"
+        eType="#//Statement" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="AssignmentKind">
+    <eLiterals name="ASSIGN" value="1" literal="="/>
+    <eLiterals name="PLUS_ASSIGN" value="2" literal="+="/>
+    <eLiterals name="MINUS_ASSIGN" value="3" literal="-="/>
+    <eLiterals name="TIMES_ASSIGN" value="4" literal="*="/>
+    <eLiterals name="DIVIDE_ASSIGN" value="5" literal="/="/>
+    <eLiterals name="BIT_AND_ASSIGN" value="6" literal="&amp;="/>
+    <eLiterals name="BIT_OR_ASSIGN" value="7" literal="|="/>
+    <eLiterals name="BIT_XOR_ASSIGN" value="8" literal="^="/>
+    <eLiterals name="REMAINDER_ASSIGN" value="9" literal="%="/>
+    <eLiterals name="LEFT_SHIFT_ASSIGN" value="10" literal="&lt;&lt;="/>
+    <eLiterals name="RIGHT_SHIFT_SIGNED_ASSIGN" value="11" literal=">>="/>
+    <eLiterals name="RIGHT_SHIFT_UNSIGNED_ASSIGN" value="12" literal=">>>="/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="InfixExpressionKind">
+    <eLiterals name="TIMES" value="1" literal="*"/>
+    <eLiterals name="DIVIDE" value="2" literal="/"/>
+    <eLiterals name="REMAINDER" value="3" literal="%"/>
+    <eLiterals name="PLUS" value="4" literal="+"/>
+    <eLiterals name="MINUS" value="5" literal="-"/>
+    <eLiterals name="LEFT_SHIFT" value="6" literal="&lt;&lt;"/>
+    <eLiterals name="RIGHT_SHIFT_SIGNED" value="7" literal=">>"/>
+    <eLiterals name="RIGHT_SHIFT_UNSIGNED" value="8" literal=">>>"/>
+    <eLiterals name="LESS" value="9" literal="&lt;"/>
+    <eLiterals name="GREATER" value="10" literal=">"/>
+    <eLiterals name="LESS_EQUALS" value="11" literal="&lt;="/>
+    <eLiterals name="GREATER_EQUALS" value="12" literal=">="/>
+    <eLiterals name="EQUALS" value="13" literal="=="/>
+    <eLiterals name="NOT_EQUALS" value="14" literal="!="/>
+    <eLiterals name="XOR" value="15" literal="^"/>
+    <eLiterals name="AND" value="16" literal="&amp;"/>
+    <eLiterals name="OR" value="17" literal="|"/>
+    <eLiterals name="CONDITIONAL_AND" value="18" literal="&amp;&amp;"/>
+    <eLiterals name="CONDITIONAL_OR" value="19" literal="||"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="InheritanceKind">
+    <eLiterals name="none" value="1"/>
+    <eLiterals name="abstract" value="2"/>
+    <eLiterals name="final" value="3"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="PostfixExpressionKind">
+    <eLiterals name="INCREMENT" value="1" literal="++"/>
+    <eLiterals name="DECREMENT" value="2" literal="--"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="PrefixExpressionKind">
+    <eLiterals name="INCREMENT" value="1" literal="++"/>
+    <eLiterals name="DECREMENT" value="2" literal="--"/>
+    <eLiterals name="PLUS" value="3" literal="+"/>
+    <eLiterals name="MINUS" value="4" literal="-"/>
+    <eLiterals name="COMPLEMENT" value="5" literal="~"/>
+    <eLiterals name="NOT" value="6" literal="!"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="VisibilityKind">
+    <eLiterals name="none" value="1"/>
+    <eLiterals name="public" value="2"/>
+    <eLiterals name="private" value="3"/>
+    <eLiterals name="protected" value="4"/>
+  </eClassifiers>
+</ecore:EPackage>

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/main.egx
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/imports/main.egx
@@ -1,0 +1,2 @@
+import "dot/dot.egx";
+import "barchart/barchart.egx";


### PR DESCRIPTION
Besides setting the template factory root prior to parsing, this adds a test for how relative paths to EGL files are resolved from imported EGX modules, which should help catch any future regressions of the same kind. The same test was passing in 2.8, and in the current tip of main if I `git revert`ed the fix for #203 (17e770b6640f11d525eff2ec0f9e6866b9091d50).

Fixes #206