### PR TITLE
Added Parametrised Simulink Block Constructor

### DIFF
--- a/examples/org.eclipse.epsilon.emc.simulink.examples/create/createSimpleSimulation.eol
+++ b/examples/org.eclipse.epsilon.emc.simulink.examples/create/createSimpleSimulation.eol
@@ -13,6 +13,19 @@ assert(BusCreator.all.size() = 1);
 var scope = new `simulink/Sinks/Scope`;
 assert(Scope.all.size() = 1);
 
+// Test creating a new block within an existing subsystem
+var subsys = new `simulink/Ports & Subsystems/Subsystem`;
+subsys.name = "TestSubsystem";
+var childSubsys = new `simulink/Ports & Subsystems/Subsystem`(subsys.path);
+assert(childSubsys.parent.path == subsys.path);
+
+// Test creating a new block on an empty path (this is expected
+// to create the block at the top level of the model)
+var blockAtTopLevel = new `simulink/Commonly Used Blocks/In1`(null);
+var anotherBlockAtTopLevel = new `simulink/Commonly Used Blocks/Out1`("");
+assert(blockAtTopLevel.parent == null);
+assert(anotherBlockAtTopLevel.parent == null);
+
 sineWave.position = "[100 100 130 130]";
 assert(sineWave.position.at(0) = 100);
 assert(sineWave.position.at(1) = 100);

--- a/examples/org.eclipse.epsilon.emc.simulink.examples/create/createSimpleSimulation.eol
+++ b/examples/org.eclipse.epsilon.emc.simulink.examples/create/createSimpleSimulation.eol
@@ -13,19 +13,6 @@ assert(BusCreator.all.size() = 1);
 var scope = new `simulink/Sinks/Scope`;
 assert(Scope.all.size() = 1);
 
-// Test creating a new block within an existing subsystem
-var subsys = new `simulink/Ports & Subsystems/Subsystem`;
-subsys.name = "TestSubsystem";
-var childSubsys = new `simulink/Ports & Subsystems/Subsystem`(subsys.path);
-assert(childSubsys.parent.path == subsys.path);
-
-// Test creating a new block on an empty path (this is expected
-// to create the block at the top level of the model)
-var blockAtTopLevel = new `simulink/Commonly Used Blocks/In1`(null);
-var anotherBlockAtTopLevel = new `simulink/Commonly Used Blocks/Out1`("");
-assert(blockAtTopLevel.parent == null);
-assert(anotherBlockAtTopLevel.parent == null);
-
 sineWave.position = "[100 100 130 130]";
 assert(sineWave.position.at(0) = 100);
 assert(sineWave.position.at(1) = 100);

--- a/plugins/org.eclipse.epsilon.emc.simulink/src/org/eclipse/epsilon/emc/simulink/model/SimulinkModel.java
+++ b/plugins/org.eclipse.epsilon.emc.simulink/src/org/eclipse/epsilon/emc/simulink/model/SimulinkModel.java
@@ -240,6 +240,13 @@ public class SimulinkModel extends AbstractSimulinkModel implements IOperationCo
 			} catch (EolRuntimeException e) {
 				throw new EolModelElementTypeNotFoundException(type, null, e.getMessage());
 			}
+		} else if (type.contains("/") && parameters.size() == 1) {
+			Object parentPath = parameters.toArray()[0];
+			try {
+				return new SimulinkBlock(this, engine, type, (String) parentPath);
+			} catch (MatlabRuntimeException e) {
+				throw new EolNotInstantiableModelElementTypeException(getSimulinkModelName(), type);
+			}
 		}
 		throw new EolModelElementTypeNotFoundException(type, null);
 	}

--- a/plugins/org.eclipse.epsilon.emc.simulink/src/org/eclipse/epsilon/emc/simulink/model/element/SimulinkBlock.java
+++ b/plugins/org.eclipse.epsilon.emc.simulink/src/org/eclipse/epsilon/emc/simulink/model/element/SimulinkBlock.java
@@ -45,6 +45,10 @@ public class SimulinkBlock extends SimulinkElement {
 	 * @throws EolRuntimeException
 	 */
 
+	public SimulinkBlock(SimulinkModel model, MatlabEngine engine, String type, String destPath) throws MatlabRuntimeException {
+		super(model, engine, type, destPath);
+	}
+	
 	public SimulinkBlock(SimulinkModel model, MatlabEngine engine, Double handle) throws MatlabRuntimeException {
 		super(model, engine, handle);
 	}

--- a/plugins/org.eclipse.epsilon.emc.simulink/src/org/eclipse/epsilon/emc/simulink/model/element/SimulinkElement.java
+++ b/plugins/org.eclipse.epsilon.emc.simulink/src/org/eclipse/epsilon/emc/simulink/model/element/SimulinkElement.java
@@ -32,6 +32,34 @@ public abstract class SimulinkElement extends SimulinkModelElement {
 	protected static final String GET_HANDLE_PROPERTY = "get_param(handle, '?');";
 
 	protected Double handle = null;
+	
+	// Used when creating a new block on a given path
+	public SimulinkElement(SimulinkModel model, MatlabEngine engine, String type, String destPath) throws MatlabRuntimeException {
+		super(model, engine);
+		try {
+			String parentSysPath;
+			
+			// If the path to the parent (sub)system is not provided, create the block
+			// at the top level of the Simulink model. This should be consistent with
+			// the behaviour exhibited when re-parenting blocks
+			if (destPath != null && !destPath.isEmpty()) {
+				parentSysPath = destPath;
+			} else {
+				parentSysPath = model.getSimulinkModelName();
+			}
+			
+			this.handle = (Double) engine.evalWithResult(ADD_BLOCK_MAKE_NAME_UNIQUE_ON, type,
+					parentSysPath + "/" + SimulinkUtil.getSimpleTypeName(type));
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new MatlabRuntimeException("Unable to create block element");
+		}
+		try {
+			setType();
+		} catch (MatlabException e) {
+			throw new MatlabRuntimeException("Unable to set up the type");
+		}
+	}
 
 	// Used when creating blocks
 	public SimulinkElement(SimulinkModel model, MatlabEngine engine, String type) throws MatlabRuntimeException {

--- a/tests/org.eclipse.epsilon.emc.simulink.test/resources/example_scripts/createBlocksWithPaths.eol
+++ b/tests/org.eclipse.epsilon.emc.simulink.test/resources/example_scripts/createBlocksWithPaths.eol
@@ -1,0 +1,12 @@
+// Test creating a new block within an existing subsystem
+var subsys = new `simulink/Ports & Subsystems/Subsystem`;
+subsys.name = "TestSubsystem";
+var childSubsys = new `simulink/Ports & Subsystems/Subsystem`(subsys.path);
+assert(childSubsys.parent.path == subsys.path);
+
+// Test creating a new block on an empty path (this is expected
+// to create the block at the top level of the model)
+var blockAtTopLevel = new `simulink/Commonly Used Blocks/In1`(null);
+var anotherBlockAtTopLevel = new `simulink/Commonly Used Blocks/Out1`("");
+assert(blockAtTopLevel.parent == null);
+assert(anotherBlockAtTopLevel.parent == null);

--- a/tests/org.eclipse.epsilon.emc.simulink.test/resources/example_scripts/createSimpleSimulation.eol
+++ b/tests/org.eclipse.epsilon.emc.simulink.test/resources/example_scripts/createSimpleSimulation.eol
@@ -13,6 +13,19 @@ assert(BusCreator.all.size() = 1);
 var scope = new `simulink/Sinks/Scope`;
 assert(Scope.all.size() = 1);
 
+// Test creating a new block within an existing subsystem
+var subsys = new `simulink/Ports & Subsystems/Subsystem`;
+subsys.name = "TestSubsystem";
+var childSubsys = new `simulink/Ports & Subsystems/Subsystem`(subsys.path);
+assert(childSubsys.parent.path == subsys.path);
+
+// Test creating a new block on an empty path (this is expected
+// to create the block at the top level of the model)
+var blockAtTopLevel = new `simulink/Commonly Used Blocks/In1`(null);
+var anotherBlockAtTopLevel = new `simulink/Commonly Used Blocks/Out1`("");
+assert(blockAtTopLevel.parent == null);
+assert(anotherBlockAtTopLevel.parent == null);
+
 sineWave.position = "[100 100 130 130]";
 assert(sineWave.position.at(0) = 100);
 assert(sineWave.position.at(1) = 100);

--- a/tests/org.eclipse.epsilon.emc.simulink.test/resources/example_scripts/createSimpleSimulation.eol
+++ b/tests/org.eclipse.epsilon.emc.simulink.test/resources/example_scripts/createSimpleSimulation.eol
@@ -13,19 +13,6 @@ assert(BusCreator.all.size() = 1);
 var scope = new `simulink/Sinks/Scope`;
 assert(Scope.all.size() = 1);
 
-// Test creating a new block within an existing subsystem
-var subsys = new `simulink/Ports & Subsystems/Subsystem`;
-subsys.name = "TestSubsystem";
-var childSubsys = new `simulink/Ports & Subsystems/Subsystem`(subsys.path);
-assert(childSubsys.parent.path == subsys.path);
-
-// Test creating a new block on an empty path (this is expected
-// to create the block at the top level of the model)
-var blockAtTopLevel = new `simulink/Commonly Used Blocks/In1`(null);
-var anotherBlockAtTopLevel = new `simulink/Commonly Used Blocks/Out1`("");
-assert(blockAtTopLevel.parent == null);
-assert(anotherBlockAtTopLevel.parent == null);
-
 sineWave.position = "[100 100 130 130]";
 assert(sineWave.position.at(0) = 100);
 assert(sineWave.position.at(1) = 100);

--- a/tests/org.eclipse.epsilon.emc.simulink.test/src/org/eclipse/epsilon/emc/simulink/test/unit/ExampleTests.java
+++ b/tests/org.eclipse.epsilon.emc.simulink.test/src/org/eclipse/epsilon/emc/simulink/test/unit/ExampleTests.java
@@ -39,6 +39,11 @@ public class ExampleTests extends AbstractSimulinkTest {
 	}
 	
 	@Test
+	public void testCreateBlocksWithPath() {
+		eolResourceFile = ROOT + "createBlocksWithPaths.eol";
+	}
+	
+	@Test
 	public void testLinkPortsWithStringNames() {
 		eolResourceFile = ROOT + "linkStringPorts.eol";
 	}


### PR DESCRIPTION
In order to allow for more flexibility when creating Similink blocks, new `SimulinkElement` and `SimulinkBlock` constructors have been implemented to facilitate the creation of a block on a given path. The path is provided as a parameter to the constructor.