### PR TITLE
Fix EMG nextFromCollection crash with single-element collections

### DIFF
--- a/plugins/org.eclipse.epsilon.emg.engine/src/org/eclipse/epsilon/emg/random/EmgRandomGenerator.java
+++ b/plugins/org.eclipse.epsilon.emg.engine/src/org/eclipse/epsilon/emg/random/EmgRandomGenerator.java
@@ -288,6 +288,12 @@ public class EmgRandomGenerator implements IEmgRandomGenerator<IEmgRandomGenerat
 	@Override
 	public Object nextFromCollection(Collection<?> c) {
 
+		if (c.isEmpty()) {
+			throw new IllegalArgumentException("Cannot select from an empty collection");
+		}
+		if (c.size() == 1) {
+			return c.iterator().next();
+		}
 		int upper = c.size() - 1;
 		int index = 0;
 		try {


### PR DESCRIPTION
## Summary

Fixes #223 — `nextFromCollection` crashes when the collection has 0 or 1 elements.

## Problem

`EmgRandomGenerator.nextFromCollection()` calls `nextInteger(0, c.size() - 1)`. Apache Commons Math 3 `UniformIntegerDistribution` requires strict `lower < upper`, so:
- Size 1 → `nextInt(0, 0)` → crash
- Size 0 → `nextInt(0, -1)` → crash

This occurs when using `@list` with `$instances` where the list has the same number of elements as instances being created (common pattern for deterministic naming).

## Fix

Guard at the top of `nextFromCollection`:
- Empty collection → throw clear `IllegalArgumentException`
- Single element → return it directly without random selection

## Testing

Verified manually with EMG scripts using `$instances 1` + single-element `@list`.